### PR TITLE
feat: add copy to clipboard button on attack tab for findings

### DIFF
--- a/packages/frontend/src/components/attacks/Container.vue
+++ b/packages/frontend/src/components/attacks/Container.vue
@@ -1377,12 +1377,21 @@ const createFindingFromResult = async (result: AttackResult) => {
 const copyFindingToClipboard = async (
   finding: AttackResult["findings"][number],
 ) => {
+  const evidence =
+    finding.evidence !== undefined && finding.evidence.trim() !== ""
+      ? `\n\nEvidence:\n${finding.evidence}`
+      : "";
+  const recommendation =
+    finding.recommendation !== undefined &&
+    finding.recommendation.trim() !== ""
+      ? `\n\nRecommendation:\n${finding.recommendation}`
+      : "";
   const findingText = `${finding.title}
 
 Severity: ${finding.severity.toUpperCase()}
 
 Description:
-${finding.description}${finding.evidence ? `\n\nEvidence:\n${finding.evidence}` : ""}${finding.recommendation ? `\n\nRecommendation:\n${finding.recommendation}` : ""}`;
+${finding.description}${evidence}${recommendation}`;
 
   await copyToClipboard(findingText);
 };
@@ -2355,6 +2364,7 @@ export default {
                                           icon="fas fa-copy"
                                           size="small"
                                           severity="secondary"
+                                          aria-label="Copy finding to clipboard"
                                           @click="copyFindingToClipboard(finding)"
                                           v-tooltip="'Copy to clipboard'"
                                         />

--- a/packages/frontend/src/components/attacks/Container.vue
+++ b/packages/frontend/src/components/attacks/Container.vue
@@ -1374,6 +1374,19 @@ const createFindingFromResult = async (result: AttackResult) => {
   }
 };
 
+const copyFindingToClipboard = async (
+  finding: AttackResult["findings"][number],
+) => {
+  const findingText = `${finding.title}
+
+Severity: ${finding.severity.toUpperCase()}
+
+Description:
+${finding.description}${finding.evidence ? `\n\nEvidence:\n${finding.evidence}` : ""}${finding.recommendation ? `\n\nRecommendation:\n${finding.recommendation}` : ""}`;
+
+  await copyToClipboard(findingText);
+};
+
 const sendToReplay = async (result: AttackResult) => {
   if (result.rawRequest === undefined || result.rawRequest === "") {
     sdk.window.showToast("No request data available for replay", {
@@ -2337,6 +2350,14 @@ export default {
                                         >
                                           {{ finding.severity }}
                                         </span>
+
+                                        <Button
+                                          icon="fas fa-copy"
+                                          size="small"
+                                          severity="secondary"
+                                          @click="copyFindingToClipboard(finding)"
+                                          v-tooltip="'Copy to clipboard'"
+                                        />
 
                                         <!-- Create Finding Button (for all severities) -->
                                         <Button


### PR DESCRIPTION
love this plugin, thanks bro
small PR to create a copy to clipboard button on attack tab for findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-click copy action for each security finding.
  * Copied content includes the finding’s title, severity, description, and any available evidence or recommendation.
  * The existing finding creation flow remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->